### PR TITLE
Enable tests in C++ workflow

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -16,4 +16,5 @@ jobs:
       - name: Build
         run: cmake --build build
       - name: Run tests
-        run: ctest --test-dir build --output-on-failure
+        working-directory: build
+        run: ctest --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ FetchContent_MakeAvailable(spdlog)
 # CMAKE MODULES
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/)
 include(Tools)
+enable_testing()
 
 add_subdirectory(abstract-document)
 add_subdirectory(abstract-factory)


### PR DESCRIPTION
## Summary
- enable CMake testing to register test targets
- run tests from the build directory in the CI workflow

## Testing
- `ctest --test-dir build -R builder-test --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b5f71afc18832db403be1c096e78b3