### PR TITLE
Simplify header include paths

### DIFF
--- a/abstract-document/src/App.cpp
+++ b/abstract-document/src/App.cpp
@@ -2,9 +2,9 @@
 // Created by Mateusz Paszkowski on 01.07.2023.
 //
 
-#include "../include/App.h"
-#include "../include/Car.h"
-#include "../include/enum/Property.h"
+#include "App.h"
+#include "Car.h"
+#include "enum/Property.h"
 #include <spdlog/spdlog.h>
 
 using spdlog::info;

--- a/abstract-document/src/enum/Property.cpp
+++ b/abstract-document/src/enum/Property.cpp
@@ -2,7 +2,7 @@
 // Created by Mateusz Paszkowski on 01.07.2023.
 //
 
-#include "../../include/enum/Property.h"
+#include "enum/Property.h"
 
 namespace dp
 {

--- a/arrange-act-assert/src/Cash.cpp
+++ b/arrange-act-assert/src/Cash.cpp
@@ -2,24 +2,23 @@
 // Created by Mateusz Paszkowski on 17.07.2023.
 //
 
-#include "../include/Cash.h"
+#include "Cash.h"
 
-Cash::Cash(int amount) : amount(amount) {
-}
+Cash::Cash(int amount) : amount(amount) {}
 
-void Cash::plus(int addend) {
-    amount += addend;
-}
+void Cash::plus(int addend) { amount += addend; }
 
-bool Cash::minus(int subtrahend) {
-    if (amount >= subtrahend) {
+bool Cash::minus(int subtrahend)
+{
+    if (amount >= subtrahend)
+    {
         amount -= subtrahend;
         return true;
-    } else {
+    }
+    else
+    {
         return false;
     }
 }
 
-int Cash::count() const {
-    return amount;
-}
+int Cash::count() const { return amount; }


### PR DESCRIPTION
## Summary
- Reintroduce `enum` directory in abstract-document includes
- Drop redundant `include/enum` directory from CMake configuration

## Testing
- `./configure`
- `cmake --build build -j 2`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b68c81a26c832db873b6897e8dd8f2