### PR TITLE
Refactor abstract document for safer property access

### DIFF
--- a/abstract-document/include/AbstractDocument.h
+++ b/abstract-document/include/AbstractDocument.h
@@ -12,13 +12,13 @@ namespace dp
 class AbstractDocument : public virtual Document
 {
 public:
-    AbstractDocument() noexcept;
+    AbstractDocument() noexcept = default;
     explicit AbstractDocument(const std::map<std::string, std::any>& properties);
-    AbstractDocument(const AbstractDocument& other);
-    AbstractDocument(AbstractDocument&& other) noexcept;
+    AbstractDocument(const AbstractDocument& other)            = default;
+    AbstractDocument(AbstractDocument&& other) noexcept        = default;
 
-    AbstractDocument&      operator=(const AbstractDocument& abstractDocument);
-    AbstractDocument&      operator=(AbstractDocument&& abstractDocument) noexcept;
+    AbstractDocument& operator=(const AbstractDocument& abstractDocument) = default;
+    AbstractDocument& operator=(AbstractDocument&& abstractDocument) noexcept = default;
 
     void                   put(const std::string& key, const std::any& value) override;
     [[nodiscard]] std::any get(const std::string& key) const noexcept override;

--- a/abstract-document/include/HasModel.h
+++ b/abstract-document/include/HasModel.h
@@ -16,7 +16,12 @@ class HasModel : public virtual Document
 public:
     [[nodiscard]] std::optional<std::string> getModel() const
     {
-        return std::any_cast<std::string>(get(to_string(Property::MODEL)));
+        auto value = get(to_string(Property::MODEL));
+        if (const auto model = std::any_cast<std::string>(&value))
+        {
+            return *model;
+        }
+        return std::nullopt;
     }
 };
 } // namespace dp

--- a/abstract-document/include/HasPrice.h
+++ b/abstract-document/include/HasPrice.h
@@ -14,7 +14,15 @@ namespace dp
 class HasPrice : public virtual Document
 {
 public:
-    [[nodiscard]] std::optional<long> getPrice() const { return std::any_cast<long>(get(to_string(Property::PRICE))); }
+    [[nodiscard]] std::optional<long> getPrice() const
+    {
+        auto value = get(to_string(Property::PRICE));
+        if (const auto price = std::any_cast<long>(&value))
+        {
+            return *price;
+        }
+        return std::nullopt;
+    }
 };
 } // namespace dp
 

--- a/abstract-document/include/HasType.h
+++ b/abstract-document/include/HasType.h
@@ -16,7 +16,12 @@ class HasType : public virtual Document
 public:
     [[nodiscard]] std::optional<std::string> getType() const
     {
-        return std::any_cast<std::string>(get(to_string(Property::TYPE)));
+        auto value = get(to_string(Property::TYPE));
+        if (const auto type = std::any_cast<std::string>(&value))
+        {
+            return *type;
+        }
+        return std::nullopt;
     }
 };
 } // namespace dp

--- a/abstract-document/src/AbstractDocument.cpp
+++ b/abstract-document/src/AbstractDocument.cpp
@@ -6,19 +6,12 @@
 
 namespace dp
 {
-AbstractDocument::AbstractDocument() noexcept = default;
-
 AbstractDocument::AbstractDocument(const std::map<std::string, std::any>& properties) : properties_(properties) {}
 
-AbstractDocument::AbstractDocument(const AbstractDocument& other)                           = default;
-
-AbstractDocument::AbstractDocument(AbstractDocument&& other) noexcept                       = default;
-
-AbstractDocument& AbstractDocument::operator=(const AbstractDocument& abstractDocument)     = default;
-
-AbstractDocument& AbstractDocument::operator=(AbstractDocument&& abstractDocument) noexcept = default;
-
-void     AbstractDocument::put(const std::string& key, const std::any& value) { properties_.emplace(key, value); }
+void AbstractDocument::put(const std::string& key, const std::any& value)
+{
+    properties_.insert_or_assign(key, value);
+}
 
 std::any AbstractDocument::get(const std::string& key) const noexcept
 {
@@ -31,16 +24,11 @@ std::any AbstractDocument::get(const std::string& key) const noexcept
 
 std::vector<std::map<std::string, std::any>> AbstractDocument::children(const std::string& key) const noexcept
 {
-    if (auto value = get(key); value.has_value())
+    auto value = get(key);
+    if (const auto child =
+            std::any_cast<std::vector<std::map<std::string, std::any>>>(&value))
     {
-        try
-        {
-            return std::any_cast<std::vector<std::map<std::string, std::any>>>(value);
-        }
-        catch (const std::bad_any_cast&)
-        {
-            return {};
-        }
+        return *child;
     }
     return {};
 }

--- a/abstract-document/tests/domain_test.cpp
+++ b/abstract-document/tests/domain_test.cpp
@@ -42,3 +42,11 @@ TEST(abstract_document, should_construct_car)
     GTEST_ASSERT_EQ(TEST_CAR_PRICE, car.getPrice().value());
     GTEST_ASSERT_EQ(2, car.getParts().size());
 }
+
+TEST(abstract_document, should_return_nullopt_for_missing_properties)
+{
+    auto car = Car(std::map<std::string, std::any>{});
+    GTEST_ASSERT_FALSE(car.getModel().has_value());
+    GTEST_ASSERT_FALSE(car.getPrice().has_value());
+    GTEST_ASSERT_TRUE(car.getParts().empty());
+}


### PR DESCRIPTION
## Summary
- use `insert_or_assign` and pointer `std::any_cast` to avoid exceptions
- default special members and modernize optional property access
- add test for missing properties in abstract document

## Testing
- `./configure`
- `cmake --build build`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b6b9d974f0832dba49b0f44b7fd4ca